### PR TITLE
Fix for linking server certificate fails

### DIFF
--- a/mynsconfig.py.example
+++ b/mynsconfig.py.example
@@ -2,12 +2,15 @@ nitroNSIP = "192.168.2.54"
 nitroUser = "nsroot"
 nitroPass = "nsroot"
 
+passplain = "#S0m3C0mpl3xPassw0rd123#"
+
+
 #Use HTTP or HTTPs to connect to Netscaler
 connectiontype = "https"
 
 #Certificate and private key file names on Netscaler
 #Pair Name Prefix (le-certificate-mydomain)
-nspairname = "le-certificate"
+nspairname = "le-"
 #File Name Prefix (le-cert-myhostname.domain.com.pem)
 nscert = "le-cert"
 nskey = "le-privkey"

--- a/mynsconfig.py.example
+++ b/mynsconfig.py.example
@@ -2,6 +2,7 @@ nitroNSIP = "192.168.2.54"
 nitroUser = "nsroot"
 nitroPass = "nsroot"
 
+#don't delete passplain. It is random and is only used as a dummy passphrase when creating the server certificate (NetScaler requires a passphrase for pem files)
 passplain = "#S0m3C0mpl3xPassw0rd123#"
 
 


### PR DESCRIPTION
added pem passphrase for creating server certificate
added TLD to server certificate name on NetScaler. Certificate creating otherwise fails when having multiple domains with different top-level domains like mydomain.com and mydomain.ch (certificate name would be in both cases le-certificate-mydomain). 
Added error output when creating server certificate for easier troubleshooting

replaced
`nspairname = "le-certificate"`
with 
`nspairname = "le-"`
to prevent long names (NetScaler allows at max 31 characters for server certificate names, which can be a problem when having long domain names)