### PR TITLE
Conflict with nspairname/nscert/nskey

### DIFF
--- a/ns-copytons.py
+++ b/ns-copytons.py
@@ -223,7 +223,7 @@ if whattodo == "save":
    localkey = sys.argv[3]
    localchain = sys.argv[4]
    domain = sys.argv[5]
-   m = crc32(domain)
+   m = zlib.crc32(domain)
    nspairname = nspairname + "-" + m
    nscert = nscert + "-" + m + ".cert"
    nskey = nskey + "-" + m + ".key"
@@ -253,8 +253,8 @@ elif whattodo == "challenge":
    token_value = sys.argv[3]
    challenge_domain = sys.argv[4]
    domaincount = int(sys.argv[5])
-   polname = nsresppol + "-" + crc32(challenge_domain)
-   actname = nsrespact + "-" + crc32(challenge_domain)
+   polname = nsresppol + "-" + zlib.crc32(challenge_domain)
+   actname = nsrespact + "-" + zlib.crc32(challenge_domain)
    print("Creating Challenge Policy for %s" % challenge_domain)
    CreaterespAct(connectiontype,nitroNSIP,authToken,actname,token_value)
    CreaterespPol(connectiontype,nitroNSIP,authToken,polname,token_filename,actname)
@@ -270,8 +270,8 @@ elif whattodo == "challenge":
   
 elif whattodo == "clean":
    challenge_domain = sys.argv[2]
-   polname = nsresppol + "-" + crc32(challenge_domain)
-   actname = nsrespact + "-" + crc32(challenge_domain)
+   polname = nsresppol + "-" + zlib.crc32(challenge_domain)
+   actname = nsrespact + "-" + zlib.crc32(challenge_domain)
    print("Removing Challenge Policy for %s" % challenge_domain)
    if viptype == "csw":
        UnBindrespPolCSW(connectiontype,nitroNSIP,authToken,polname,nsvip)

--- a/ns-copytons.py
+++ b/ns-copytons.py
@@ -3,7 +3,7 @@
 #USE AT OWN RISK
 
 #Imports
-import json, requests, base64, sys, os, re
+import json, zlib, requests, base64, sys, os, re
 requests.packages.urllib3.disable_warnings()
 #imports variables used for script
 from mynsconfig import *
@@ -223,7 +223,7 @@ if whattodo == "save":
    localkey = sys.argv[3]
    localchain = sys.argv[4]
    domain = sys.argv[5]
-   m = domain[:60]
+   m = crc32(domain)
    nspairname = nspairname + "-" + m
    nscert = nscert + "-" + m + ".cert"
    nskey = nskey + "-" + m + ".key"
@@ -253,8 +253,8 @@ elif whattodo == "challenge":
    token_value = sys.argv[3]
    challenge_domain = sys.argv[4]
    domaincount = int(sys.argv[5])
-   polname = nsresppol + "-" + challenge_domain[:60]
-   actname = nsrespact + "-" + challenge_domain[:60]
+   polname = nsresppol + "-" + crc32(challenge_domain)
+   actname = nsrespact + "-" + crc32(challenge_domain)
    print("Creating Challenge Policy for %s" % challenge_domain)
    CreaterespAct(connectiontype,nitroNSIP,authToken,actname,token_value)
    CreaterespPol(connectiontype,nitroNSIP,authToken,polname,token_filename,actname)
@@ -270,8 +270,8 @@ elif whattodo == "challenge":
   
 elif whattodo == "clean":
    challenge_domain = sys.argv[2]
-   polname = nsresppol + "-" + challenge_domain[:60]
-   actname = nsrespact + "-" + challenge_domain[:60]
+   polname = nsresppol + "-" + crc32(challenge_domain)
+   actname = nsrespact + "-" + crc32(challenge_domain)
    print("Removing Challenge Policy for %s" % challenge_domain)
    if viptype == "csw":
        UnBindrespPolCSW(connectiontype,nitroNSIP,authToken,polname,nsvip)

--- a/ns-copytons.py
+++ b/ns-copytons.py
@@ -223,7 +223,7 @@ if whattodo == "save":
    localkey = sys.argv[3]
    localchain = sys.argv[4]
    domain = sys.argv[5]
-   m = zlib.crc32(domain)
+   m = zlib.crc32(domain.encode('utf8'))
    nspairname = nspairname + "-" + m
    nscert = nscert + "-" + m + ".cert"
    nskey = nskey + "-" + m + ".key"
@@ -253,8 +253,8 @@ elif whattodo == "challenge":
    token_value = sys.argv[3]
    challenge_domain = sys.argv[4]
    domaincount = int(sys.argv[5])
-   polname = nsresppol + "-" + zlib.crc32(challenge_domain)
-   actname = nsrespact + "-" + zlib.crc32(challenge_domain)
+   polname = nsresppol + "-" + zlib.crc32(challenge_domain.encode('utf8'))
+   actname = nsrespact + "-" + zlib.crc32(challenge_domain.encode('utf8'))
    print("Creating Challenge Policy for %s" % challenge_domain)
    CreaterespAct(connectiontype,nitroNSIP,authToken,actname,token_value)
    CreaterespPol(connectiontype,nitroNSIP,authToken,polname,token_filename,actname)
@@ -270,8 +270,8 @@ elif whattodo == "challenge":
   
 elif whattodo == "clean":
    challenge_domain = sys.argv[2]
-   polname = nsresppol + "-" + zlib.crc32(challenge_domain)
-   actname = nsrespact + "-" + zlib.crc32(challenge_domain)
+   polname = nsresppol + "-" + zlib.crc32(challenge_domain.encode('utf8'))
+   actname = nsrespact + "-" + zlib.crc32(challenge_domain.encode('utf8'))
    print("Removing Challenge Policy for %s" % challenge_domain)
    if viptype == "csw":
        UnBindrespPolCSW(connectiontype,nitroNSIP,authToken,polname,nsvip)

--- a/ns-copytons.py
+++ b/ns-copytons.py
@@ -223,7 +223,7 @@ if whattodo == "save":
    localkey = sys.argv[3]
    localchain = sys.argv[4]
    domain = sys.argv[5]
-   m = domain[:20]
+   m = domain[:60]
    nspairname = nspairname + "-" + m
    nscert = nscert + "-" + m + ".cert"
    nskey = nskey + "-" + m + ".key"
@@ -253,8 +253,8 @@ elif whattodo == "challenge":
    token_value = sys.argv[3]
    challenge_domain = sys.argv[4]
    domaincount = int(sys.argv[5])
-   polname = nsresppol + "-" + challenge_domain[:20]
-   actname = nsrespact + "-" + challenge_domain[:20]
+   polname = nsresppol + "-" + challenge_domain[:60]
+   actname = nsrespact + "-" + challenge_domain[:60]
    print("Creating Challenge Policy for %s" % challenge_domain)
    CreaterespAct(connectiontype,nitroNSIP,authToken,actname,token_value)
    CreaterespPol(connectiontype,nitroNSIP,authToken,polname,token_filename,actname)
@@ -270,8 +270,8 @@ elif whattodo == "challenge":
   
 elif whattodo == "clean":
    challenge_domain = sys.argv[2]
-   polname = nsresppol + "-" + challenge_domain[:20]
-   actname = nsrespact + "-" + challenge_domain[:20]
+   polname = nsresppol + "-" + challenge_domain[:60]
+   actname = nsrespact + "-" + challenge_domain[:60]
    print("Removing Challenge Policy for %s" % challenge_domain)
    if viptype == "csw":
        UnBindrespPolCSW(connectiontype,nitroNSIP,authToken,polname,nsvip)

--- a/ns-copytons.py
+++ b/ns-copytons.py
@@ -223,10 +223,10 @@ if whattodo == "save":
    localkey = sys.argv[3]
    localchain = sys.argv[4]
    domain = sys.argv[5]
-   m = re.search("(.+?)(?=\.)", domain)
-   nspairname = nspairname + "-" + m.group(0)[:20]
-   nscert = nscert + "-" + m.group(0)[:20] + ".cert"
-   nskey = nskey + "-" + m.group(0)[:20] + ".key"
+   m = domain[:20]
+   nspairname = nspairname + "-" + m
+   nscert = nscert + "-" + m + ".cert"
+   nskey = nskey + "-" + m + ".key"
    existcode = GetSSL(connectiontype,nitroNSIP,authToken, nspairname)
    if existcode == 200:
        print("Using existing cert")


### PR DESCRIPTION
If I create a cert test.foo.com the nscert/nskey/nspairname will just be named le-test. So if I want to make test.example.org we'll end up conflicting nscert/nskey/nspairname.

It looks it was introduced in #7

https://developer-docs.citrix.com/projects/netscaler-command-reference/en/12.0/ssl/ssl-certkey/ssl-certkey/
Where do you get your 20 character limit from ? We can safely raise the limit to 30.